### PR TITLE
2d spectrum as 1d should always convert to flux units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,8 @@ Specviz2d
 Other Changes and Additions
 ---------------------------
 
+- When importing a 2D spectrum file into a SpectrumList, surface brightness units are automatically converted to flux units. [#3729]
+
 4.3.1 (unreleased)
 ==================
 

--- a/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
+++ b/jdaviz/configs/specviz/plugins/unit_conversion/unit_conversion.py
@@ -19,7 +19,7 @@ from jdaviz.core.unit_conversion_utils import (create_equivalent_spectral_axis_u
                                                create_equivalent_flux_units_list,
                                                check_if_unit_is_per_solid_angle,
                                                create_equivalent_angle_units_list,
-                                               supported_sq_angle_units)
+                                               flux_to_sb_unit)
 
 __all__ = ['UnitConversion']
 
@@ -40,16 +40,6 @@ def _valid_glue_display_unit(unit_str, viewer, axis='x'):
         raise ValueError(f"{unit_str} could not find match in valid {axis} display units {choices_str}")  # noqa
     ind = choices_u.index(unit_u)
     return choices_str[ind]
-
-
-def _flux_to_sb_unit(flux_unit, angle_unit):
-    if angle_unit not in supported_sq_angle_units(as_strings=True):
-        sb_unit = flux_unit
-    else:
-        # str > unit > str to remove formatting inconsistencies with
-        # parentheses/order of units/etc
-        sb_unit = (u.Unit(flux_unit) / u.Unit(angle_unit)).to_string()
-    return sb_unit
 
 
 @tray_registry('g-unit-conversion', label="Unit Conversion",
@@ -383,8 +373,8 @@ class UnitConversion(PluginTemplateMixin):
                 # which in turn will call _handle_attribute_display_unit,
                 # _handle_spectral_y_unit (if spectral_y_type_selected == 'Surface Brightness'),
                 #  and send a second GlobalDisplayUnitChanged message for sb
-                self.sb_unit_selected = _flux_to_sb_unit(self.flux_unit.selected,
-                                                         self.angle_unit.selected)
+                self.sb_unit_selected = flux_to_sb_unit(self.flux_unit.selected,
+                                                        self.angle_unit.selected)
 
         elif axis == 'angle':
             if len(self.flux_unit_selected):
@@ -392,8 +382,8 @@ class UnitConversion(PluginTemplateMixin):
                 # which in turn will call _handle_attribute_display_unit,
                 # _handle_spectral_y_unit (if spectral_y_type_selected == 'Surface Brightness'),
                 #  and send a second GlobalDisplayUnitChanged message for sb
-                self.sb_unit_selected = _flux_to_sb_unit(self.flux_unit.selected,
-                                                         self.angle_unit.selected)
+                self.sb_unit_selected = flux_to_sb_unit(self.flux_unit.selected,
+                                                        self.angle_unit.selected)
 
         elif axis == 'sb':
             # handle spectral y-unit first since that is a more apparent change to the user

--- a/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
@@ -46,12 +46,12 @@ class SpectrumListImporter(BaseImporterToDataCollection):
 
         exposures = []
         sources_options = []
-    
+
         if isinstance(self.input, Spectrum):
             speclist_input = SpectrumList(self.input_to_list_of_spec(self.input))
         else:
             speclist_input = self.input
-    
+
         for index, spec in enumerate(speclist_input):
             if self.is_wfssmulti(spec):
                 # ver, name are stand-ins for exposure and source_id
@@ -59,19 +59,19 @@ class SpectrumListImporter(BaseImporterToDataCollection):
                 ver, name = self._extract_exposure_sourceid(spec)
                 exposure_label = f"Exposure {ver}"
                 exposures.append(exposure_label)
-    
+
                 label = f"{exposure_label}, Source ID: {name}"
                 # Flipping the two from the variable naming convention
                 name_ver = f"{ver}_{name}"
                 suffix = f"EXP-{ver}_ID-{name}"
-    
+
             else:
                 name_ver = index
                 name = index
                 ver = index
                 label = f"1D Spectrum at index: {index}"
                 suffix = f"index-{index}"
-    
+
             sources_options.append({'label': label,
                                     'index': index,
                                     'name': str(name),
@@ -79,16 +79,16 @@ class SpectrumListImporter(BaseImporterToDataCollection):
                                     'name_ver': str(name_ver),
                                     'suffix': suffix,
                                     'obj': self._apply_spectral_mask(spec)})
-    
+
         self.sources = SelectFileExtensionComponent(self,
                                                     items='sources_items',
                                                     selected='sources_selected',
                                                     multiselect='sources_multiselect',
                                                     manual_options=sources_options)
-    
+
         self.sources.selected = []
         self._sources_items_helper = deepcopy(self.sources.items)
-    
+
         if len(exposures) > 0:
             exposures_options = [{'label': exp, 'index': i, 'ver': exp,
                                   'name': exp, 'name_ver': exp, 'suffix': None}
@@ -99,14 +99,14 @@ class SpectrumListImporter(BaseImporterToDataCollection):
                                                           multiselect='exposures_multiselect',
                                                           manual_options=exposures_options)
             self.exposures.selected = []
-    
+
             self._exposures_helper = defaultdict(list)
             for item in self.sources.items:
                 if 'Exposure' in item['label']:
                     # For grouping items by exposure
                     key = f"Exposure {item['ver']}"
                     self._exposures_helper[key].append(item)
-    
+
         # TODO: This observer will likely be removed in follow-up effort
         # If the resolver format is set to "1D Spectrum List", then we
         # only enable the import button if at least one spectrum is selected.

--- a/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
@@ -44,73 +44,73 @@ class SpectrumListImporter(BaseImporterToDataCollection):
         else:
             self.data_label_default = '1D Spectrum'
 
-      exposures = []
-      sources_options = []
-  
-      if isinstance(self.input, Spectrum):
-          speclist_input = SpectrumList(self.input_to_list_of_spec(self.input))
-      else:
-          speclist_input = self.input
-  
-      for index, spec in enumerate(speclist_input):
-          if self.is_wfssmulti(spec):
-              # ver, name are stand-ins for exposure and source_id
-              # ver == exposure, name == source_id
-              ver, name = self._extract_exposure_sourceid(spec)
-              exposure_label = f"Exposure {ver}"
-              exposures.append(exposure_label)
-  
-              label = f"{exposure_label}, Source ID: {name}"
-              # Flipping the two from the variable naming convention
-              name_ver = f"{ver}_{name}"
-              suffix = f"EXP-{ver}_ID-{name}"
-  
-          else:
-              name_ver = index
-              name = index
-              ver = index
-              label = f"1D Spectrum at index: {index}"
-              suffix = f"index-{index}"
-  
-          sources_options.append({'label': label,
-                                  'index': index,
-                                  'name': str(name),
-                                  'ver': str(ver),
-                                  'name_ver': str(name_ver),
-                                  'suffix': suffix,
-                                  'obj': self._apply_spectral_mask(spec)})
-  
-      self.sources = SelectFileExtensionComponent(self,
-                                                  items='sources_items',
-                                                  selected='sources_selected',
-                                                  multiselect='sources_multiselect',
-                                                  manual_options=sources_options)
-  
-      self.sources.selected = []
-      self._sources_items_helper = deepcopy(self.sources.items)
-  
-      if len(exposures) > 0:
-          exposures_options = [{'label': exp, 'index': i, 'ver': exp,
-                                'name': exp, 'name_ver': exp, 'suffix': None}
-                               for i, exp in enumerate(sorted(set(exposures)))]
-          self.exposures = SelectFileExtensionComponent(self,
-                                                        items='exposures_items',
-                                                        selected='exposures_selected',
-                                                        multiselect='exposures_multiselect',
-                                                        manual_options=exposures_options)
-          self.exposures.selected = []
-  
-          self._exposures_helper = defaultdict(list)
-          for item in self.sources.items:
-              if 'Exposure' in item['label']:
-                  # For grouping items by exposure
-                  key = f"Exposure {item['ver']}"
-                  self._exposures_helper[key].append(item)
-  
-      # TODO: This observer will likely be removed in follow-up effort
-      # If the resolver format is set to "1D Spectrum List", then we
-      # only enable the import button if at least one spectrum is selected.
-      self.resolver.observe(self._on_format_selected_change, names='format_selected')
+        exposures = []
+        sources_options = []
+    
+        if isinstance(self.input, Spectrum):
+            speclist_input = SpectrumList(self.input_to_list_of_spec(self.input))
+        else:
+            speclist_input = self.input
+    
+        for index, spec in enumerate(speclist_input):
+            if self.is_wfssmulti(spec):
+                # ver, name are stand-ins for exposure and source_id
+                # ver == exposure, name == source_id
+                ver, name = self._extract_exposure_sourceid(spec)
+                exposure_label = f"Exposure {ver}"
+                exposures.append(exposure_label)
+    
+                label = f"{exposure_label}, Source ID: {name}"
+                # Flipping the two from the variable naming convention
+                name_ver = f"{ver}_{name}"
+                suffix = f"EXP-{ver}_ID-{name}"
+    
+            else:
+                name_ver = index
+                name = index
+                ver = index
+                label = f"1D Spectrum at index: {index}"
+                suffix = f"index-{index}"
+    
+            sources_options.append({'label': label,
+                                    'index': index,
+                                    'name': str(name),
+                                    'ver': str(ver),
+                                    'name_ver': str(name_ver),
+                                    'suffix': suffix,
+                                    'obj': self._apply_spectral_mask(spec)})
+    
+        self.sources = SelectFileExtensionComponent(self,
+                                                    items='sources_items',
+                                                    selected='sources_selected',
+                                                    multiselect='sources_multiselect',
+                                                    manual_options=sources_options)
+    
+        self.sources.selected = []
+        self._sources_items_helper = deepcopy(self.sources.items)
+    
+        if len(exposures) > 0:
+            exposures_options = [{'label': exp, 'index': i, 'ver': exp,
+                                  'name': exp, 'name_ver': exp, 'suffix': None}
+                                 for i, exp in enumerate(sorted(set(exposures)))]
+            self.exposures = SelectFileExtensionComponent(self,
+                                                          items='exposures_items',
+                                                          selected='exposures_selected',
+                                                          multiselect='exposures_multiselect',
+                                                          manual_options=exposures_options)
+            self.exposures.selected = []
+    
+            self._exposures_helper = defaultdict(list)
+            for item in self.sources.items:
+                if 'Exposure' in item['label']:
+                    # For grouping items by exposure
+                    key = f"Exposure {item['ver']}"
+                    self._exposures_helper[key].append(item)
+    
+        # TODO: This observer will likely be removed in follow-up effort
+        # If the resolver format is set to "1D Spectrum List", then we
+        # only enable the import button if at least one spectrum is selected.
+        self.resolver.observe(self._on_format_selected_change, names='format_selected')
 
     @property
     def user_api(self):

--- a/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
@@ -7,7 +7,7 @@ from astropy.nddata import StdDevUncertainty
 from specutils import Spectrum, SpectrumList, SpectrumCollection
 from traitlets import List, Bool, Any, observe
 
-from jdaviz.core.unit_conversion_utils import sb_to_flux_unit, spectrum_ensure_flux_unit
+from jdaviz.core.unit_conversion_utils import to_flux_density_unit, spectrum_ensure_flux_density_unit
 from jdaviz.core.registries import loader_importer_registry
 from jdaviz.core.loaders.importers import BaseImporterToDataCollection
 from jdaviz.core.template_mixin import SelectFileExtensionComponent
@@ -181,13 +181,13 @@ class SpectrumListImporter(BaseImporterToDataCollection):
         if isinstance(inp, Spectrum):
             if inp.flux.ndim == 1:
                 # Note masks (currently) only applied when spectral_axis has missing values
-                return [spectrum_ensure_flux_unit(self._apply_spectral_mask(inp))]
+                return [spectrum_ensure_flux_density_unit(self._apply_spectral_mask(inp))]
 
-            return [spectrum_ensure_flux_unit(Spectrum(spectral_axis=inp.spectral_axis,
-                                                       flux=this_row(inp.flux, i),
-                                                       uncertainty=this_row(inp.uncertainty, i),
-                                                       mask=this_row(inp.mask, i),
-                                                       meta=inp.meta))
+            return [spectrum_ensure_flux_density_unit(Spectrum(spectral_axis=inp.spectral_axis,
+                                                      flux=this_row(inp.flux, i),
+                                                      uncertainty=this_row(inp.uncertainty, i),
+                                                      mask=this_row(inp.mask, i),
+                                                      meta=inp.meta))
                     for i in range(inp.flux.shape[0])]
 
         elif isinstance(inp, (SpectrumList, SpectrumCollection)):
@@ -358,7 +358,7 @@ class SpectrumListConcatenatedImporter(SpectrumListImporter):
 
         wave_units = spec.spectral_axis.unit
         pixar_sr = getattr(spec, 'meta', {}).get('PIXAR_SR', 1.0)
-        flux_units = sb_to_flux_unit(spec.flux.unit, pixar_sr)
+        flux_units = to_flux_density_unit(spec.flux.unit, pixar_sr)
 
         return combine_lists_to_1d_spectrum(wlallorig,
                                             fnuallorig,

--- a/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
@@ -44,73 +44,73 @@ class SpectrumListImporter(BaseImporterToDataCollection):
         else:
             self.data_label_default = '1D Spectrum'
 
-    exposures = []
-    sources_options = []
-
-    if isinstance(self.input, Spectrum):
-        speclist_input = SpectrumList(self.input_to_list_of_spec(self.input))
-    else:
-        speclist_input = self.input
-
-    for index, spec in enumerate(speclist_input):
-        if self.is_wfssmulti(spec):
-            # ver, name are stand-ins for exposure and source_id
-            # ver == exposure, name == source_id
-            ver, name = self._extract_exposure_sourceid(spec)
-            exposure_label = f"Exposure {ver}"
-            exposures.append(exposure_label)
-
-            label = f"{exposure_label}, Source ID: {name}"
-            # Flipping the two from the variable naming convention
-            name_ver = f"{ver}_{name}"
-            suffix = f"EXP-{ver}_ID-{name}"
-
-        else:
-            name_ver = index
-            name = index
-            ver = index
-            label = f"1D Spectrum at index: {index}"
-            suffix = f"index-{index}"
-
-        sources_options.append({'label': label,
-                                'index': index,
-                                'name': str(name),
-                                'ver': str(ver),
-                                'name_ver': str(name_ver),
-                                'suffix': suffix,
-                                'obj': self._apply_spectral_mask(spec)})
-
-    self.sources = SelectFileExtensionComponent(self,
-                                                items='sources_items',
-                                                selected='sources_selected',
-                                                multiselect='sources_multiselect',
-                                                manual_options=sources_options)
-
-    self.sources.selected = []
-    self._sources_items_helper = deepcopy(self.sources.items)
-
-    if len(exposures) > 0:
-        exposures_options = [{'label': exp, 'index': i, 'ver': exp,
-                              'name': exp, 'name_ver': exp, 'suffix': None}
-                             for i, exp in enumerate(sorted(set(exposures)))]
-        self.exposures = SelectFileExtensionComponent(self,
-                                                      items='exposures_items',
-                                                      selected='exposures_selected',
-                                                      multiselect='exposures_multiselect',
-                                                      manual_options=exposures_options)
-        self.exposures.selected = []
-
-        self._exposures_helper = defaultdict(list)
-        for item in self.sources.items:
-            if 'Exposure' in item['label']:
-                # For grouping items by exposure
-                key = f"Exposure {item['ver']}"
-                self._exposures_helper[key].append(item)
-
-    # TODO: This observer will likely be removed in follow-up effort
-    # If the resolver format is set to "1D Spectrum List", then we
-    # only enable the import button if at least one spectrum is selected.
-    self.resolver.observe(self._on_format_selected_change, names='format_selected')
+      exposures = []
+      sources_options = []
+  
+      if isinstance(self.input, Spectrum):
+          speclist_input = SpectrumList(self.input_to_list_of_spec(self.input))
+      else:
+          speclist_input = self.input
+  
+      for index, spec in enumerate(speclist_input):
+          if self.is_wfssmulti(spec):
+              # ver, name are stand-ins for exposure and source_id
+              # ver == exposure, name == source_id
+              ver, name = self._extract_exposure_sourceid(spec)
+              exposure_label = f"Exposure {ver}"
+              exposures.append(exposure_label)
+  
+              label = f"{exposure_label}, Source ID: {name}"
+              # Flipping the two from the variable naming convention
+              name_ver = f"{ver}_{name}"
+              suffix = f"EXP-{ver}_ID-{name}"
+  
+          else:
+              name_ver = index
+              name = index
+              ver = index
+              label = f"1D Spectrum at index: {index}"
+              suffix = f"index-{index}"
+  
+          sources_options.append({'label': label,
+                                  'index': index,
+                                  'name': str(name),
+                                  'ver': str(ver),
+                                  'name_ver': str(name_ver),
+                                  'suffix': suffix,
+                                  'obj': self._apply_spectral_mask(spec)})
+  
+      self.sources = SelectFileExtensionComponent(self,
+                                                  items='sources_items',
+                                                  selected='sources_selected',
+                                                  multiselect='sources_multiselect',
+                                                  manual_options=sources_options)
+  
+      self.sources.selected = []
+      self._sources_items_helper = deepcopy(self.sources.items)
+  
+      if len(exposures) > 0:
+          exposures_options = [{'label': exp, 'index': i, 'ver': exp,
+                                'name': exp, 'name_ver': exp, 'suffix': None}
+                               for i, exp in enumerate(sorted(set(exposures)))]
+          self.exposures = SelectFileExtensionComponent(self,
+                                                        items='exposures_items',
+                                                        selected='exposures_selected',
+                                                        multiselect='exposures_multiselect',
+                                                        manual_options=exposures_options)
+          self.exposures.selected = []
+  
+          self._exposures_helper = defaultdict(list)
+          for item in self.sources.items:
+              if 'Exposure' in item['label']:
+                  # For grouping items by exposure
+                  key = f"Exposure {item['ver']}"
+                  self._exposures_helper[key].append(item)
+  
+      # TODO: This observer will likely be removed in follow-up effort
+      # If the resolver format is set to "1D Spectrum List", then we
+      # only enable the import button if at least one spectrum is selected.
+      self.resolver.observe(self._on_format_selected_change, names='format_selected')
 
     @property
     def user_api(self):

--- a/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
@@ -7,7 +7,8 @@ from astropy.nddata import StdDevUncertainty
 from specutils import Spectrum, SpectrumList, SpectrumCollection
 from traitlets import List, Bool, Any, observe
 
-from jdaviz.core.unit_conversion_utils import to_flux_density_unit, spectrum_ensure_flux_density_unit
+from jdaviz.core.unit_conversion_utils import (to_flux_density_unit,
+                                               spectrum_ensure_flux_density_unit)
 from jdaviz.core.registries import loader_importer_registry
 from jdaviz.core.loaders.importers import BaseImporterToDataCollection
 from jdaviz.core.template_mixin import SelectFileExtensionComponent

--- a/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.vue
+++ b/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.vue
@@ -30,6 +30,16 @@
       ></plugin-select>
     </div>
 
+    <v-row v-if="input_in_sb">
+      <plugin-switch
+        :value.sync="convert_to_flux_density"
+        label="Convert to flux density units"
+        api_hint="ldr.importer.convert_to_flux_density = "
+        :api_hints_enabled="api_hints_enabled"
+        hint="Whether to convert any input surface brightness units to flux density."
+      ></plugin-switch>
+    </v-row>
+
     <div style="height: 16px;"></div>
 
     <v-row>

--- a/jdaviz/core/loaders/importers/spectrum_list/test_spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/test_spectrum_list.py
@@ -529,7 +529,7 @@ class TestSpectrumListConcatenatedImporter:
                            for sp in importer_obj.output])
         else:
             assert spectrum2d.flux.unit.physical_type == 'spectral flux density'
-            assert u.Unit(importer_obj.output.flux.unit.to_string()).physical_type == 'spectral flux density'
+            assert u.Unit(importer_obj.output.flux.unit.to_string()).physical_type == 'spectral flux density'  # noa
 
     @pytest.mark.parametrize('with_uncertainty', [True, False])
     def test_spectrum_list_concatenated_importer_output(self, deconfigged_helper, with_uncertainty):

--- a/jdaviz/core/loaders/importers/spectrum_list/test_spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/test_spectrum_list.py
@@ -523,6 +523,16 @@ class TestSpectrumListConcatenatedImporter:
         assert importer_obj.disable_dropdown is not use_list
         assert importer_obj.resolver.import_disabled is False
 
+        # ensure native units on surface brightness or spectral flux density are converted to flux
+        if use_list:
+            assert np.all([sp.flux.unit.physical_type == 'spectral flux density'
+                           for sp in premade_spectrum_list])
+            assert np.all([sp.flux.unit.physical_type == 'spectral flux density'
+                           for sp in importer_obj.output])
+        else:
+            assert spectrum2d.flux.unit.physical_type == 'spectral flux density'
+            assert u.Unit(importer_obj.output.flux.unit.to_string()).physical_type == 'spectral flux density'
+
     @pytest.mark.parametrize('with_uncertainty', [True, False])
     def test_spectrum_list_concatenated_importer_output(self, deconfigged_helper, with_uncertainty):
         spec = self.setup_combined_spectrum(with_uncertainty)

--- a/jdaviz/core/unit_conversion_utils.py
+++ b/jdaviz/core/unit_conversion_utils.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 import itertools
 
 from astropy import units as u
+from specutils import Spectrum
 import numpy as np
 
 from jdaviz.core.custom_units_and_equivs import (PIX2,
@@ -17,7 +18,8 @@ __all__ = ["all_flux_unit_conversion_equivs", "check_if_unit_is_per_solid_angle"
            "create_equivalent_spectral_axis_units_list",
            "flux_conversion_general", "handle_squared_flux_unit_conversions",
            "supported_sq_angle_units", "spectral_axis_conversion",
-           "units_to_strings"]
+           "units_to_strings", "flux_to_sb_unit", "sb_to_flux_unit",
+           "spectrum_ensure_sb_unit", "spectrum_ensure_flux_unit"]
 
 
 def all_flux_unit_conversion_equivs(pixar_sr=None, cube_wave=None):
@@ -534,3 +536,83 @@ def convert_integrated_sb_unit(u1, spectral_axis_unit, desired_freq_unit, desire
         return u1  # units are compatible, return input
 
     return uu * spec_axis_conversion_scale_factor
+
+
+def flux_to_sb_unit(flux_unit, angle_unit):
+    if angle_unit not in supported_sq_angle_units(as_strings=True):
+        sb_unit = flux_unit
+    else:
+        # str > unit > str to remove formatting inconsistencies with
+        # parentheses/order of units/etc
+        sb_unit = (u.Unit(flux_unit) / u.Unit(angle_unit)).to_string()
+    return sb_unit
+
+
+def sb_to_flux_unit(sb_unit, pixar_sr=1.0):
+    if sb_unit.physical_type == 'flux':
+        return sb_unit
+
+    # Extract the angle/pixel unit from the surface brightness unit
+    angle_unit = check_if_unit_is_per_solid_angle(sb_unit, return_unit=True)
+
+    # Default behavior: extract angle unit or fallback to steradian
+    if angle_unit is None:
+        angle_unit = u.sr
+    return sb_unit * pixar_sr * angle_unit
+
+
+def spectrum_ensure_sb_unit(spectrum, angle_unit):
+    if spectrum.flux.unit.physical_type == 'surface brightness':
+        return spectrum
+
+    sb_unit = u.Unit(flux_to_sb_unit(spectrum.flux.unit, angle_unit))
+
+    # Handle uncertainty conversion based on type
+    if spectrum.uncertainty is not None:
+        if hasattr(spectrum.uncertainty, 'quantity'):
+            # StdDevUncertainty or similar - use quantity for proper unit handling
+            # Preserve the original uncertainty class
+            uncertainty_class = spectrum.uncertainty.__class__
+            new_uncertainty = uncertainty_class(spectrum.uncertainty.quantity.value * sb_unit)
+        else:
+            # Simple array-like uncertainty
+            new_uncertainty = spectrum.uncertainty.value * sb_unit
+    else:
+        new_uncertainty = None
+
+    return Spectrum(
+        spectral_axis=spectrum.spectral_axis,
+        flux=spectrum.flux.value * sb_unit,
+        uncertainty=new_uncertainty,
+        mask=spectrum.mask,
+        meta=spectrum.meta
+    )
+
+
+def spectrum_ensure_flux_unit(spectrum):
+    if spectrum.flux.unit.physical_type == 'flux':
+        return spectrum
+
+    pixar_sr = getattr(spectrum, 'meta', {}).get('PIXAR_SR', 1.0)
+    flux_unit = u.Unit(sb_to_flux_unit(spectrum.flux.unit, pixar_sr))
+
+    # Handle uncertainty conversion based on type
+    if spectrum.uncertainty is not None:
+        if hasattr(spectrum.uncertainty, 'quantity'):
+            # StdDevUncertainty or similar - use quantity for proper unit handling
+            # Preserve the original uncertainty class
+            uncertainty_class = spectrum.uncertainty.__class__
+            new_uncertainty = uncertainty_class(spectrum.uncertainty.quantity.value * flux_unit)
+        else:
+            # Simple array-like uncertainty
+            new_uncertainty = spectrum.uncertainty.value * flux_unit
+    else:
+        new_uncertainty = None
+
+    return Spectrum(
+        spectral_axis=spectrum.spectral_axis,
+        flux=spectrum.flux.value * flux_unit,
+        uncertainty=new_uncertainty,
+        mask=spectrum.mask,
+        meta=spectrum.meta
+    )


### PR DESCRIPTION
This PR ensures that 1D spectra (especially when extracted from 2D spectra) are in flux units when returned by the `SpectrumList` or `SpectrumListConcatenated` importers so that the unit collision does not result in creating unnecessary additional viewers.