### PR TITLE
POC: alternative approach for warning only through .load

### DIFF
--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -213,9 +213,7 @@ class ConfigHelper(HubListener):
             kwargs['viewer'] = '*' if kwargs.pop('show_in_viewer') else []
 
         importer = resolver.importer
-        for k, v in kwargs.items():
-            if hasattr(importer, k) and v is not None:
-                setattr(importer, k, v)
+        importer._apply_kwargs(kwargs)
         return importer()
 
     @property

--- a/jdaviz/core/helpers.py
+++ b/jdaviz/core/helpers.py
@@ -213,7 +213,7 @@ class ConfigHelper(HubListener):
             kwargs['viewer'] = '*' if kwargs.pop('show_in_viewer') else []
 
         importer = resolver.importer
-        importer._apply_kwargs(kwargs)
+        importer._obj._apply_kwargs(kwargs)
         return importer()
 
     @property

--- a/jdaviz/core/loaders/importers/importer.py
+++ b/jdaviz/core/loaders/importers/importer.py
@@ -54,6 +54,16 @@ class BaseImporter(PluginTemplateMixin):
     def __repr__(self):
         return f"<{self.__class__.__name__}>"
 
+    def _apply_kwargs(self, kwargs):
+        user_api = self.user_api
+        applied_kwargs = []
+        for k, v in kwargs.items():
+            if hasattr(user_api, k) and v is not None:
+                setattr(user_api, k, v)
+                applied_kwargs.append(k)
+
+        return applied_kwargs
+
     @property
     def is_valid(self):
         # override by subclass

--- a/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
@@ -93,6 +93,16 @@ class SpectrumListImporter(BaseImporterToDataCollection):
         # only enable the import button if at least one spectrum is selected.
         self.resolver.observe(self._on_format_selected_change, names='format_selected')
 
+    def _apply_kwargs(self, kwargs):
+        applied_kwargs = super()._apply_kwargs(kwargs)
+        if 'sources' not in applied_kwargs:
+            msg_str = (f"The default source selection ({self.sources.selected}) will be used.\n"
+                       f"To load additional sources, please specify them via dropdown or "
+                       f"as follows:\n'{self.config}.load(filename, sources = [...]).")
+            msg = SnackbarMessage(msg_str, color='warning', sender=self, timeout=10000)
+            self.app.hub.broadcast(msg)
+            warnings.warn(msg_str)
+
     @staticmethod
     def _get_supported_viewers():
         return [{'label': '1D Spectrum', 'reference': 'spectrum-1d-viewer'}]

--- a/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
+++ b/jdaviz/core/loaders/importers/spectrum_list/spectrum_list.py
@@ -102,6 +102,7 @@ class SpectrumListImporter(BaseImporterToDataCollection):
             msg = SnackbarMessage(msg_str, color='warning', sender=self, timeout=10000)
             self.app.hub.broadcast(msg)
             warnings.warn(msg_str)
+        return applied_kwargs
 
     @staticmethod
     def _get_supported_viewers():


### PR DESCRIPTION
This PR shows a generalized infrastructure that could allow importers to raise warnings for passed/unpassed kwargs passed through `.load(...)` (but not from the loaders API or UI).

Pros:
* pretty lightweight and general in the code
* doesn't show warning from UI

Pro/Con (depends who you ask):
* doesn't show warning when using loader API